### PR TITLE
Update svelte.config.js

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,8 +13,6 @@ const config = {
         // You can create optimized builds for different platforms by
         // specifying a different adapter
         adapter: nodeAdapter(),
-        // hydrate the <div id="svelte"> element in src/app.html
-        target: '#svelte',
         // vite options
         vite: {
             // The File Upload plugin


### PR DESCRIPTION
Error message: config.kit.target is no longer required, and should be removed 
Similar to https://github.com/sveltejs/kit/discussions/3695