### PR TITLE
fileToUpload=false doesn't match type assignment

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -3,7 +3,7 @@
     const filesPath = '/'; // in this example: static root
 
     /* The File object from the form */
-    let fileToUpload = false;
+    let fileToUpload = null;
     let fileName = ''
 
     /* The button status */


### PR DESCRIPTION
I use typescript. It complains, because the boolean type `false` doesn't match the file type the `fileToUpload` will be set to later. I suggest setting it to null for usage by a wider audience. 
The `!fileToUpload` check also works with null.